### PR TITLE
Add CLI interface

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,5 +36,12 @@ jobs:
       - name: Test
         run: npm run test:light
 
+      - name: Smoke test CLI in tarball
+        run: |
+          PACK=$(npm pack --silent)
+          mkdir _smoke && cd _smoke && npm init -y >/dev/null
+          npm install "../$PACK" --silent
+          npx fpi --version
+
       - name: Publish to npm
         run: npm publish --provenance --access public

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 test/.dual-mode*
 test/downloaded-packages
 test/.*cache*
+cli-test-results.md

--- a/README.md
+++ b/README.md
@@ -384,6 +384,14 @@ fpi [options] [command]
 
 Run `fpi <command> --help` to see all options available for a specific command.
 
+### Claude Code Skill
+
+This repository ships a [Claude Code](https://code.claude.com/docs) skill that teaches Claude how to drive the `fpi` CLI — command syntax, aliases, global flags, common workflows, and known gotchas (offline mode, identifier syntax, `--raw` for scripting, etc.).
+
+- **Location:** [`skills/fpi-cli/SKILL.md`](skills/fpi-cli/SKILL.md)
+- **What it does:** When you ask Claude to install, download, inspect, or check FHIR packages from the CLI (e.g. _"install hl7.fhir.r4.core@4.0.1 into ./cache"_, _"is hl7.fhir.uv.sdc cached?"_, _"what's the latest version of hl7.terminology.r4?"_), Claude will automatically invoke this skill and use the right `fpi` invocation instead of guessing.
+- **How to enable it:** Claude Code auto-discovers skills under `skills/` in the workspace. No installation step is required — just open this repo in Claude Code (or any Claude environment that supports project-local skills) and start asking package questions.
+
 ---
 
 ## License

--- a/README.md
+++ b/README.md
@@ -334,6 +334,58 @@ Sample structure:
 
 ---
 
+## CLI
+
+In addition to its programmatic API, FHIR Package Installer also provides a fully featured Command Line Interface (CLI) for installing, managing, and inspecting FHIR packages directly from the terminal.
+
+This is especially useful for:
+- Tooling pipelines (e.g., CI/CD)
+- Scripted validators and snapshot generators
+- Developers who prefer using the CLI over importing the library
+
+### Usage
+
+```
+fpi [options] [command]
+```
+
+### Global Options
+
+| Option                            | Description                                                                       |
+| --------------------------------- | --------------------------------------------------------------------------------- |
+| `-r`, `--registry-url <url>`      | URL of the FHIR package registry (use `n/a` to disable network access)            |
+| `-t`, `--registry-token <token>`  | Bearer token for authenticating against a private registry                        |
+| `-c`, `--cache-path <path>`       | Path to the FHIR package cache directory                                          |
+| `-s`, `--skip-examples`           | Skip dependency installation of example packages                                  |
+| `--allow-http`                    | Allow HTTP (non-HTTPS) registry URLs (for testing)                                |
+| `--request-timeout <ms>`          | HTTP request timeout in milliseconds (default: 90000)                             |
+| `--extract-timeout <ms>`          | Tarball extraction timeout in milliseconds (default: 60000)                       |
+| `--registry-ttl <ms>`             | TTL for cached registry lookups in milliseconds (default: 1800000 = 30 minutes)   |
+| `-v`, `--verbose`                 | Enable verbose (debug) logging                                                    |
+| `-V`, `--version`                 | Output the version number                                                         |
+| `-h`, `--help`                    | Display help for command                                                          |
+
+### Commands
+
+| Command                              | Description                                                                    |
+| ------------------------------------ | ------------------------------------------------------------------------------ |
+| `install`, `i <packageId>`           | Download and install a package and all its dependencies                        |
+| `download`, `dl <packageId>`         | Download a package tarball and optionally extract it to a destination          |
+| `install-local`, `il <src>`          | Install a package from a local file or directory                               |
+| `get-manifest`, `gm <packageId>`     | Print the `package.json` manifest of an installed package                      |
+| `get-index`, `gi <packageId>`        | Print the `.fpi.index.json` content for the package. Auto-generates if missing |
+| `get-dependencies`, `gd <packageId>` | Parse and list dependencies (explicit + implicit) of a package                 |
+| `to-package-object`, `tpo <id>`      | Parse `name`, `name@version`, or `name#version` into `{ id, version }`         |
+| `check-latest`, `cl <packageName>`   | Resolve the latest published version of a package from the registry            |
+| `is-installed`, `is <packageId>`     | Check if a package (and its dependencies) exist in the local cache             |
+| `get-cache`, `gc`                    | Print the root cache directory path                                            |
+| `get-package-path`, `gp <id>`        | Print the path to a specific cached package                                    |
+| `help [command]`                     | Display help for a specific command                                            |
+
+Run `fpi <command> --help` to see all options available for a specific command.
+
+---
+
 ## License
 MIT  
 © Outburn Ltd. 2022–2025. All Rights Reserved.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,15 @@
       "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
+        "@commander-js/extra-typings": "^14.0.0",
+        "commander": "^14.0.3",
         "fs-extra": "^11.3.5",
         "p-limit": "^7.3.0",
         "semver": "^7.8.0",
         "tar-stream": "^3.2.0"
+      },
+      "bin": {
+        "fpi": "dist/cli.mjs"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -31,6 +36,15 @@
         "tsup": "^8.5.1",
         "typescript": "^5.9.3",
         "vitest": "^4.1.6"
+      }
+    },
+    "node_modules/@commander-js/extra-typings": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@commander-js/extra-typings/-/extra-typings-14.0.0.tgz",
+      "integrity": "sha512-hIn0ncNaJRLkZrxBIp5AsW/eXEHNKYQBh0aPdoUqNgD+Io3NIykQqpKFyKcuasZhicGaEZJX/JBSIkZ4e5x8Dg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "commander": "~14.0.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -878,9 +892,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -898,9 +909,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -918,9 +926,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -938,9 +943,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -958,9 +960,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -978,9 +977,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1159,9 +1155,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1176,9 +1169,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1193,9 +1183,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1210,9 +1197,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1227,9 +1211,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1244,9 +1225,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1261,9 +1239,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1278,9 +1253,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1295,9 +1267,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1312,9 +1281,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1329,9 +1295,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1346,9 +1309,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1363,9 +1323,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1933,13 +1890,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "dev": true,
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "license": "MIT",
       "engines": {
-        "node": ">= 6"
+        "node": ">=20"
       }
     },
     "node_modules/confbox": {
@@ -2724,9 +2680,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2748,9 +2701,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2772,9 +2722,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2796,9 +2743,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3526,6 +3470,16 @@
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/sucrase/node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/tar-stream": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "type": "module",
+  "bin": {
+    "fpi": "./dist/cli.mjs"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -58,9 +61,12 @@
     "test:light": "cross-env FPI_SKIP_LIVE_REGISTRY=1 FPI_SKIP_VSAC_STRESS=1 FPI_SKIP_SYNTH_STRESS=1 vitest run",
     "test:dual-mode": "vitest run test/fhir-package-installer.dual-mode.test.ts",
     "test:mock-server": "vitest run test/mock-artifactory-server.test.ts",
+    "npm:link": "npm run build && npm unlink -g fhir-package-installer && npm link",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
+    "@commander-js/extra-typings": "^14.0.0",
+    "commander": "^14.0.3",
     "fs-extra": "^11.3.5",
     "p-limit": "^7.3.0",
     "semver": "^7.8.0",

--- a/scripts/cli-smoke.ps1
+++ b/scripts/cli-smoke.ps1
@@ -1,0 +1,132 @@
+$ErrorActionPreference = 'Continue'
+
+$repoRoot   = (Resolve-Path "$PSScriptRoot\..").Path
+$outFile    = Join-Path $repoRoot 'cli-test-results.md'
+$cliPath    = Join-Path $repoRoot 'dist\cli.mjs'
+$cachePath  = Join-Path $env:TEMP 'fpi-cli-test'
+$downloadPath = Join-Path $env:TEMP 'fpi-cli-dl'
+
+Remove-Item -Recurse -Force $cachePath -ErrorAction SilentlyContinue
+Remove-Item -Recurse -Force $downloadPath -ErrorAction SilentlyContinue
+New-Item -ItemType Directory $downloadPath | Out-Null
+
+"# FPI CLI smoke test results" | Set-Content -Path $outFile -Encoding utf8
+"" | Add-Content -Path $outFile
+"Generated: $(Get-Date -Format o)"            | Add-Content -Path $outFile
+"Cache path: ``$cachePath``"                  | Add-Content -Path $outFile
+"Download path: ``$downloadPath``"            | Add-Content -Path $outFile
+"" | Add-Content -Path $outFile
+
+function Invoke-Fpi {
+    param(
+        [string]$Section,
+        [string]$Description,
+        [string[]]$FpiArgs,
+        [int]$TruncateLines = 0
+    )
+
+    $displayCmd = "fpi " + ($FpiArgs -join ' ')
+    "## $Section"                  | Add-Content -Path $outFile
+    if ($Description) {
+        $Description               | Add-Content -Path $outFile
+    }
+    ""                             | Add-Content -Path $outFile
+    "Command:"                     | Add-Content -Path $outFile
+    '```'                          | Add-Content -Path $outFile
+    $displayCmd                    | Add-Content -Path $outFile
+    '```'                          | Add-Content -Path $outFile
+    ""                             | Add-Content -Path $outFile
+
+    $stdoutFile = [System.IO.Path]::GetTempFileName()
+    $stderrFile = [System.IO.Path]::GetTempFileName()
+    $proc = Start-Process -FilePath 'node' `
+        -ArgumentList (@($cliPath) + $FpiArgs) `
+        -NoNewWindow -Wait -PassThru `
+        -RedirectStandardOutput $stdoutFile `
+        -RedirectStandardError  $stderrFile
+    $exit = $proc.ExitCode
+    $stdout = Get-Content $stdoutFile -Raw -ErrorAction SilentlyContinue
+    $stderr = Get-Content $stderrFile -Raw -ErrorAction SilentlyContinue
+    Remove-Item $stdoutFile, $stderrFile -ErrorAction SilentlyContinue
+
+    if ($TruncateLines -gt 0) {
+        if ($stdout) {
+            $lines = $stdout -split "`r?`n"
+            if ($lines.Count -gt $TruncateLines) {
+                $stdout = (($lines | Select-Object -First $TruncateLines) -join "`n") + "`n... [truncated $($lines.Count - $TruncateLines) more lines]"
+            }
+        }
+    }
+
+    "Exit code: ``$exit``" | Add-Content -Path $outFile
+    ""                     | Add-Content -Path $outFile
+    if ($stdout) {
+        "stdout:"          | Add-Content -Path $outFile
+        '```'              | Add-Content -Path $outFile
+        $stdout.TrimEnd()  | Add-Content -Path $outFile
+        '```'              | Add-Content -Path $outFile
+        ""                 | Add-Content -Path $outFile
+    }
+    if ($stderr) {
+        "stderr:"          | Add-Content -Path $outFile
+        '```'              | Add-Content -Path $outFile
+        $stderr.TrimEnd()  | Add-Content -Path $outFile
+        '```'              | Add-Content -Path $outFile
+        ""                 | Add-Content -Path $outFile
+    }
+    "---" | Add-Content -Path $outFile
+    ""    | Add-Content -Path $outFile
+
+    Write-Host ("[exit=$exit] " + $displayCmd)
+}
+
+# ---- Basics ----
+Invoke-Fpi 'Version flag'   'Prints the build-injected version.'                                @('--version')
+Invoke-Fpi 'Top-level help' 'Shows ASCII banner + global options + commands.'                    @('--help') -TruncateLines 80
+Invoke-Fpi 'Per-command help' 'Help for `install` shows aliases and command-specific options.'   @('install', '--help')
+
+# ---- Read-only / resolution ----
+Invoke-Fpi 'get-cache'      'Print the resolved cache directory.'                                @('-c', $cachePath, 'get-cache')
+Invoke-Fpi 'to-package-object (pinned)' 'Parses an explicit name@version into {id,version}.'    @('-c', $cachePath, 'to-package-object', 'hl7.fhir.r4.core@4.0.1')
+Invoke-Fpi 'tpo alias (latest)' 'Alias of to-package-object; resolves "latest" via registry.'   @('-c', $cachePath, 'tpo', 'hl7.fhir.r4.core')
+Invoke-Fpi 'check-latest'   'Resolves latest published version from the registry.'              @('-c', $cachePath, 'check-latest', 'hl7.fhir.r4.core')
+Invoke-Fpi 'cl alias'       'Alias for check-latest.'                                            @('-c', $cachePath, 'cl', 'hl7.fhir.uv.sdc')
+
+# ---- Install + dependents ----
+Invoke-Fpi 'install (verbose)' 'Installs r4.core@4.0.1 with debug logging enabled.'              @('-c', $cachePath, '-v', 'install', 'hl7.fhir.r4.core@4.0.1') -TruncateLines 60
+Invoke-Fpi 'is-installed (deep)' 'Deep check including dependencies.'                            @('-c', $cachePath, 'is-installed', 'hl7.fhir.r4.core@4.0.1')
+Invoke-Fpi 'is-installed --shallow' 'Shallow check, skips dependency validation.'                @('-c', $cachePath, 'is', 'hl7.fhir.r4.core@4.0.1', '--shallow')
+Invoke-Fpi 'is-installed --raw (installed)' 'Prints raw boolean instead of a friendly message.' @('-c', $cachePath, 'is', 'hl7.fhir.r4.core@4.0.1', '--raw')
+Invoke-Fpi 'is-installed --raw (not installed)' 'Raw boolean output for a missing package.'    @('-c', $cachePath, 'is', 'does.not.exist@9.9.9', '--raw')
+Invoke-Fpi 'get-manifest'   'Print the package.json manifest (truncated).'                       @('-c', $cachePath, 'get-manifest', 'hl7.fhir.r4.core@4.0.1') -TruncateLines 25
+Invoke-Fpi 'get-index'      'Print the .fpi.index.json content (truncated).'                     @('-c', $cachePath, 'get-index', 'hl7.fhir.r4.core@4.0.1') -TruncateLines 20
+Invoke-Fpi 'get-dependencies' 'Explicit + implicit dependencies.'                                @('-c', $cachePath, 'get-dependencies', 'hl7.fhir.r4.core@4.0.1')
+Invoke-Fpi 'get-dependencies --root --planning-fallbacks' 'Graph-aware resolution flags.'        @('-c', $cachePath, 'gd', 'hl7.fhir.r4.core@4.0.1', '--root', 'hl7.fhir.r4.core@4.0.1', '--planning-fallbacks')
+Invoke-Fpi 'get-package-path' 'Print path to a specific cached package.'                         @('-c', $cachePath, 'get-package-path', 'hl7.fhir.r4.core@4.0.1')
+
+# ---- Download (no-extract, then extract+overwrite) ----
+Invoke-Fpi 'download (tarball)' 'Downloads the .tgz to a destination directory.'                 @('-c', $cachePath, 'download', 'hl7.fhir.uv.sdc@3.0.0', '-d', $downloadPath)
+Invoke-Fpi 'dl -o -e (overwrite + extract)' 'Downloads again with overwrite, then extracts.'    @('-c', $cachePath, 'dl', 'hl7.fhir.uv.sdc@3.0.0', '-d', $downloadPath, '-o', '-e')
+
+# ---- install-local ----
+$localTarball = Join-Path $downloadPath 'hl7.fhir.uv.sdc-3.0.0.tgz'
+$localExtracted = Join-Path $downloadPath 'hl7.fhir.uv.sdc#3.0.0'
+Invoke-Fpi 'install-local (tarball, custom id, override)' 'Installs from local .tgz with a custom id.' @('-c', $cachePath, 'install-local', $localTarball, '-i', 'my.local.copy@1.0.0', '-o')
+Invoke-Fpi 'il (directory, install deps)' 'Installs from an extracted directory and resolves deps.' @('-c', $cachePath, 'il', $localExtracted, '-d') -TruncateLines 60
+
+# ---- Global tuning flags ----
+Invoke-Fpi 'tuning flags + skip-examples' 'Passes through timeouts, TTL, and -s.'                @('-c', $cachePath, '--request-timeout', '60000', '--extract-timeout', '60000', '--registry-ttl', '60000', '-s', 'install', 'hl7.fhir.uv.sdc@3.0.0')
+
+# ---- Offline / registry-disabled ----
+Invoke-Fpi 'offline is-installed (cached)' 'Registry disabled (-r n/a) but package is cached.'  @('-c', $cachePath, '-r', 'n/a', 'is-installed', 'hl7.fhir.r4.core@4.0.1')
+Invoke-Fpi 'offline install (cached)' 'Registry disabled, dependency tree already cached.'      @('-c', $cachePath, '-r', 'n/a', 'install', 'hl7.fhir.r4.core@4.0.1')
+
+# ---- Failure cases ----
+Invoke-Fpi 'install missing package'   'Should fail with non-zero exit.'                         @('-c', $cachePath, 'install', 'does.not.exist@9.9.9')
+Invoke-Fpi 'offline check-latest'      'Registry disabled rejects "latest" resolution.'         @('-c', $cachePath, '-r', 'n/a', 'check-latest', 'hl7.fhir.r4.core')
+Invoke-Fpi 'bad --request-timeout'     'parseIntOption rejects non-integer values.'              @('-c', $cachePath, '--request-timeout', 'notanumber', 'install', 'hl7.fhir.r4.core@4.0.1')
+
+# ---- Auth flags smoke test ----
+Invoke-Fpi 'auth flags smoke test' 'Verifies -t / --allow-http parse and the CLI still runs.'   @('-c', $cachePath, '-t', 'dummy-token', '--allow-http', 'get-cache')
+
+Write-Host "`nDone. Results: $outFile"

--- a/skills/fpi-cli/SKILL.md
+++ b/skills/fpi-cli/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: fpi-cli
+description: Use whenever the user wants to install, download, inspect, or check FHIR packages from the command line via the `fpi` CLI (FHIR Package Installer). Covers commands like `install`, `download`, `install-local`, `get-manifest`, `get-index`, `get-dependencies`, `to-package-object`, `check-latest`, `is-installed`, `get-cache`, and `get-package-path`. Trigger even when the user just says things like "install the r4 core package", "download a FHIR package tarball", "check what version of hl7.fhir.uv.sdc is on the registry", "is this package cached", "show me the package manifest", or otherwise references FHIR packages, the FHIR package cache (`~/.fhir/packages`), or the `packages.fhir.org` registry.
+---
+
+# fpi — FHIR Package Installer CLI
+
+`fpi` is a CLI for downloading, installing, inspecting, and managing FHIR conformance packages from a FHIR package registry (default: `https://packages.fhir.org`). It maintains a local cache laid out per the FHIR Package Cache spec (`~/.fhir/packages` on user installs, `%ProgramData%\.fhir\packages` for system services).
+
+Assume `fpi` is on PATH. If it isn't, the user needs to install/build it — don't silently switch to `node dist/cli.mjs`.
+
+## Package identifier syntax
+
+Almost every command takes a `<packageId>`. Accepted forms:
+
+- `name` — resolves to the latest version via the registry
+- `name@version` — explicit version (preferred form to show users)
+- `name#version` — also accepted (matches the on-disk folder naming)
+
+Cached package folders are named `name#version` (e.g. `hl7.fhir.r4.core#4.0.1`), not with `@`. When you read paths from the cache, expect `#`. When you write commands for users, prefer `@`.
+
+## Global options (must come before the subcommand)
+
+| Flag | Meaning |
+|---|---|
+| `-r, --registry-url <url>` | Override registry URL. Pass `n/a` to disable all network access (offline mode). |
+| `-t, --registry-token <token>` | Bearer token for a private registry. |
+| `-c, --cache-path <path>` | Use a custom cache directory instead of the FHIR-spec default. |
+| `-s, --skip-examples` | Do not recurse into example packages when installing dependencies. |
+| `--allow-http` | Permit non-HTTPS registry URLs (testing only). |
+| `--request-timeout <ms>` | HTTP timeout (positive integer). |
+| `--extract-timeout <ms>` | Tarball extraction timeout (positive integer). |
+| `--registry-ttl <ms>` | TTL for cached registry metadata. |
+| `-v, --verbose` | Enable debug logging (very chatty during installs — useful for diagnosing hangs). |
+| `-V, --version` | Print CLI version. |
+| `-h, --help` | Help; works per command too (e.g. `fpi install --help`). |
+
+Order matters: global options bind to `program`, so they must precede the subcommand. `fpi install -c /tmp/x hl7.fhir.r4.core` will NOT pick up `-c`; use `fpi -c /tmp/x install hl7.fhir.r4.core`.
+
+`--request-timeout`, `--extract-timeout`, and `--registry-ttl` reject non-integers with a hard error from `parseIntOption` — don't pass `"30s"` or similar.
+
+## Commands
+
+Aliases shown in parentheses.
+
+### `install <packageId>` (`i`)
+Download a package and recursively install its dependencies, including implicit FHIR core deps (e.g. installing `hl7.fhir.r4.core@4.0.1` also pulls `hl7.terminology.r4` and `hl7.fhir.uv.extensions.r4`). Idempotent — re-running on a fully cached package is a no-op.
+
+### `download <packageId>` (`dl`)
+Download just the `.tgz` (no dependency resolution, no cache install). Options:
+- `-d, --dest <dir>` — destination directory (defaults to current location)
+- `-o, --overwrite` — overwrite existing file
+- `-e, --extract` — extract the tarball after downloading (produces a `name#version/` folder next to the `.tgz`)
+
+### `install-local <src>` (`il`)
+Install from a local `.tgz` file or an already-extracted package directory. Options:
+- `-i, --id <packageId>` — override the identifier (defaults to whatever the package's own `package.json` says)
+- `-o, --override` — overwrite existing cached copy
+- `-d, --install-dependencies` — also resolve and install the package's declared dependencies
+
+Useful when working with a package that isn't on a public registry, or for republishing under a custom id.
+
+### `get-manifest <packageId>` (`gm`)
+Print the package's `package.json` as JSON. Requires the package to be installed (won't fetch it for you).
+
+### `get-index <packageId>` (`gi`)
+Print the `.fpi.index.json` (fpi's resource index, schema-version 2). If the file is missing, fpi generates it. This file is **large** for core packages (tens of thousands of lines for r4.core) — when you call this command on behalf of the user, expect to truncate or pipe to a file.
+
+### `get-dependencies <packageId>` (`gd`)
+Print the package's effective dependency map (explicit deps from `package.json` plus implicit FHIR-core deps). Options:
+- `--root <rootPackageId>` — root package for graph-aware implicit version selection
+- `--planning-fallbacks` — include planning fallbacks for unresolved implicit deps
+
+Most callers just want `fpi gd <packageId>`; the flags are for tooling that's building a dependency plan across a graph.
+
+### `to-package-object <packageId>` (`tpo`)
+Parse `name`, `name@version`, or `name#version` into `{ "id", "version" }`. If no version is given, resolves to latest via the registry (requires network).
+
+### `check-latest <packageName>` (`cl`)
+Resolve the latest published version of `<packageName>` from the registry. Prints just the version string. Fails (exit 1) when the registry is disabled (`-r n/a`).
+
+### `is-installed <packageId>` (`is`)
+Determine whether a package is in the local cache. Options:
+- `--shallow` — only check the package itself; skip dependency validation
+- `--raw` — print just `true` / `false` instead of a friendly sentence
+
+Default output is human-friendly ("Package X is already installed."). When you need to branch on the result in a script, pass `--raw`. This command suppresses logging by design, so it's safe to capture stdout.
+
+### `get-cache` (`gc`)
+Print the resolved cache directory (after applying `-c` / env / defaults).
+
+### `get-package-path <packageId>` (`gp`)
+Print the absolute path to a specific package folder in the cache (the `name#version` directory).
+
+## Common workflows
+
+**Install a pinned package + deps into a custom cache:**
+```
+fpi -c /path/to/cache install hl7.fhir.r4.core@4.0.1
+```
+
+**Check what's on the registry without installing:**
+```
+fpi check-latest hl7.fhir.uv.sdc
+fpi tpo hl7.fhir.uv.sdc          # also resolves "latest" into {id, version}
+```
+
+**Script-friendly cache check:**
+```
+fpi -c /path/to/cache is hl7.fhir.r4.core@4.0.1 --raw
+```
+
+**Inspect an installed package:**
+```
+fpi -c /path/to/cache get-manifest hl7.fhir.r4.core@4.0.1
+fpi -c /path/to/cache get-package-path hl7.fhir.r4.core@4.0.1
+fpi -c /path/to/cache get-dependencies hl7.fhir.r4.core@4.0.1
+```
+
+**Download + extract a tarball without caching it:**
+```
+fpi download hl7.fhir.uv.sdc@3.0.0 -d ./downloads -e
+```
+
+**Reinstall from a local tarball with a custom id:**
+```
+fpi -c /path/to/cache install-local ./pkg.tgz -i my.local.copy@1.0.0 -o
+```
+
+**Offline use (registry disabled):**
+```
+fpi -c /path/to/cache -r n/a is-installed hl7.fhir.r4.core@4.0.1
+fpi -c /path/to/cache -r n/a install hl7.fhir.r4.core@4.0.1   # works only if everything is already cached
+```
+In offline mode, `check-latest` fails, and implicit dep version selection falls back to the newest version already in the cache — fpi will warn on stderr.
+
+**Diagnose a slow install:**
+```
+fpi -c /path/to/cache -v install <packageId>
+```
+`-v` emits `[timing]`, `[extract]`, `[publish]` lines and lock claim/release events — invaluable for figuring out where it's stuck.
+
+## Behavioral notes worth knowing
+
+- **Exit codes:** any unhandled error (network failure, missing package, bad input) is caught by a process-wide proxy and exits `1` with `Error in <method>: <message>` on stderr. Validation errors from `parseIntOption` exit with an uncaught stack trace (not wrapped).
+- **`is-installed` is silent.** It deliberately disables the logger so its stdout is safe to capture. Other commands print progress to stdout and may also write to stderr.
+- **Implicit deps** (per FHIR tooling convention): installing `hl7.fhir.r{3,4,5}.core` pulls a matching `hl7.terminology.r*` and `hl7.fhir.uv.extensions.r*`. Use `get-dependencies` to see the effective list.
+- **Cache layout:** packages live at `<cache>/<id>#<version>/package/...`. fpi-internal state (locks, staging, tarball cache, generated indexes) lives under `<cache>/.fpi.cache/`. Treat `.fpi.cache/` as opaque.
+- **`get-index` output is huge.** For `hl7.fhir.r4.core@4.0.1` it's ~45k lines. When running it programmatically, redirect to a file or pipe through a filter; don't dump it into a chat.
+- **Aliases are first-class.** All examples above using long names work equally with their short alias (`i`, `dl`, `il`, `gm`, `gi`, `gd`, `tpo`, `cl`, `is`, `gc`, `gp`).
+- **`--registry-url n/a`** is the supported way to assert "no network", not omitting the flag. Without it, fpi uses `https://packages.fhir.org` by default.
+
+## When NOT to reach for fpi
+
+- If the user wants to author/edit FHIR resources (StructureDefinitions, ValueSets) — that's an IG-publisher / sushi territory.
+- If they want to publish a package to a registry — fpi only consumes packages.
+- If they need npm-style semver range resolution — fpi resolves to single concrete versions, not ranges.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,261 @@
+#!/usr/bin/env node
+
+import { Command } from 'commander';
+import { FhirPackageInstaller } from '.';
+import type { FpiConfig } from './types';
+import type { Logger } from '@outburn/types';
+
+// Injected at build time via tsup `define` (see tsup.config.ts).
+declare const __FPI_VERSION__: string | undefined;
+const CLI_VERSION = typeof __FPI_VERSION__ === 'string' && __FPI_VERSION__.trim().length > 0
+  ? __FPI_VERSION__
+  : '0.0.0';
+
+// Set up the command line interface and global options
+const program = new Command()
+  .option('-r, --registry-url <url>', 'URL of the FHIR package registry (use "n/a" to disable network access)')
+  .option('-t, --registry-token <token>', 'Bearer token for authenticating against a private registry')
+  .option('-c, --cache-path <path>', 'Path to the FHIR package cache directory')
+  .option('-s, --skip-examples', 'Skip dependency installation of example packages')
+  .option('--allow-http', 'Allow HTTP (non-HTTPS) registry URLs (for testing)')
+  .option('--request-timeout <ms>', 'HTTP request timeout in milliseconds', parseIntOption)
+  .option('--extract-timeout <ms>', 'Tarball extraction timeout in milliseconds', parseIntOption)
+  .option('--registry-ttl <ms>', 'TTL for cached registry lookups in milliseconds', parseIntOption)
+  .option('-v, --verbose', 'Enable verbose (debug) logging');
+
+const ASCII_HEADER = String.raw`
+  ███████╗██████╗ ██╗
+  ██╔════╝██╔══██╗██║
+  █████╗  ██████╔╝██║
+  ██╔══╝  ██╔═══╝ ██║
+  ██║     ██║     ██║
+  ╚═╝     ╚═╝     ╚═╝
+  FHIR Package Installer
+`;
+const COPYRIGHT = '© Copyright Outburn Ltd. 2022-2026 All Rights Reserved';
+const helpText = `${ASCII_HEADER}  ${COPYRIGHT}\n\n`;
+
+program
+  .name('fpi')
+  .description('CLI for installing and managing FHIR packages')
+  .version(CLI_VERSION)
+  .addHelpText('beforeAll', helpText);
+
+// Commands
+program
+  .command('install <packageId>')
+  .alias('i')
+  .description('Download and install a package and all its dependencies')
+  .action(async (packageId) => {
+    const fpi = createFpi();
+    const installed = await fpi.install(packageId);
+    if (installed) {
+      console.log(`Package ${packageId} installed successfully.`);
+    }
+  });
+
+program
+  .command('download <packageId>')
+  .alias('dl')
+  .description('Download a package tarball and optionally extracts it to a destination directory (defaults to the current location)')
+  .option('-d, --dest <dest>', 'The directory path where the package should be saved or extracted')
+  .option('-o, --overwrite', 'Whether to overwrite the existing package if it already exists')
+  .option('-e, --extract', 'Whether to extract the package after downloading')
+  .action(async (id, opts) => {
+    const fpi = createFpi();
+    await fpi.downloadPackage(id, { destination: opts.dest, overwrite: opts.overwrite, extract: opts.extract });
+  });
+
+program
+  .command('install-local')
+  .alias('il')
+  .description('Install a package from a local file or directory')
+  .argument('<src>', 'The path to a tarball file or a directory containing the package files')
+  .option('-i, --id <packageId>', 'Specifies a custom package ID to be installed. Defaults to the package identifier from the `package.json` file')
+  .option('-o, --override', 'Whether to override the existing package if it already exists. Defaults to false')
+  .option('-d, --install-dependencies', 'Whether to install dependencies of the package. Defaults to false')
+  .action(async (src, opts) => {
+    const fpi = createFpi();
+    await fpi.installLocalPackage(src, { packageId: opts.id, override: opts.override, installDependencies: opts.installDependencies });
+  });
+
+program
+  .command('get-manifest <packageId>')
+  .alias('gm')
+  .description('Print the package.json manifest of an installed package')
+  .action(async (packageId) => {
+    const fpi = createFpi();
+    const manifest = await fpi.getManifest(packageId);
+    print(manifest);
+  });
+
+program
+  .command('get-index <packageId>')
+  .alias('gi')
+  .description('Print the `.fpi.index.json` content for the package.\nIf the file doesn\'t exist, it will be generated automatically')
+  .action(async (packageId) => {
+    const fpi = createFpi();
+    const index = await fpi.getPackageIndexFile(packageId);
+    print(index);
+  });
+
+program
+  .command('get-dependencies <packageId>')
+  .alias('gd')
+  .description('Parses dependencies listed in the package\'s package.json (includes implicit FHIR core dependencies)')
+  .option('--root <rootPackageId>', 'Root package for graph-aware implicit version selection')
+  .option('--planning-fallbacks', 'Include planning fallbacks for unresolved implicit dependencies')
+  .action(async (packageId, opts) => {
+    const fpi = createFpi();
+    const packageIdentifier = await fpi.toPackageObject(packageId);
+    const deps = await fpi.getDependencies(packageIdentifier, {
+      rootPackage: opts.root,
+      includePlanningFallbacks: opts.planningFallbacks,
+    });
+    print(deps);
+  });
+
+program
+  .command('to-package-object <packageId>')
+  .alias('tpo')
+  .description('Parses <name>, <name@version>, or <name#version> into an object with `id` and `version`.\nIf no version is provided, resolves to the latest.')
+  .action(async (packageId) => {
+    const fpi = createFpi();
+    const packageObject = await fpi.toPackageObject(packageId);
+    print(packageObject);
+  });
+
+program
+  .command('check-latest <packageName>')
+  .alias('cl')
+  .description('Resolve the latest published version of a package from the registry')
+  .action(async (packageName) => {
+    const fpi = createFpi();
+    const latest = await fpi.checkLatestPackageDist(packageName);
+    print(latest);
+  });
+
+program
+  .command('is-installed <packageId>')
+  .alias('is')
+  .description('Determine whether the package is already present in the local cache or not')
+  .option('--shallow', 'Only check whether the package itself is installed; skip dependency validation')
+  .action(async (packageId, opts) => {
+    const fpi = createFpi();
+    const isInstalled = await fpi.isInstalled(packageId, { deep: !opts.shallow });
+    if (isInstalled) {
+      print(`Package ${packageId} is already installed.`);
+    } else {
+      print(`Package ${packageId} is not installed.`);
+    }
+  });
+
+program
+  .command('get-cache')
+  .alias('gc')
+  .description('Print the root cache directory used by this installer')
+  .action(() => {
+    const fpi = createFpi();
+    const cachePath = fpi.getCachePath();
+    print(cachePath);
+  });
+
+program
+  .command('get-package-path <packageId>')
+  .alias('gp')
+  .description('Print the path to a specific package folder in the cache')
+  .action(async (packageId) => {
+    const fpi = createFpi();
+    const packagePath = await fpi.getPackageDirPath(packageId);
+    print(packagePath);
+  });
+
+program.parse();
+
+function parseIntOption(value: string): number {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`Expected a positive integer, got "${value}"`);
+  }
+  return parsed;
+}
+
+function createConsoleLogger(verbose: boolean): Logger {
+  const logger: Logger = {
+    info: (...args: unknown[]) => console.log(...args),
+    warn: (...args: unknown[]) => console.warn(...args),
+    error: (...args: unknown[]) => console.error(...args),
+  };
+  if (verbose) {
+    logger.debug = (...args: unknown[]) => console.debug(...args);
+  }
+  return logger;
+}
+
+function createFpi() {
+  const {
+    registryUrl,
+    registryToken,
+    cachePath,
+    skipExamples,
+    allowHttp,
+    requestTimeout,
+    extractTimeout,
+    registryTtl,
+    verbose,
+  } = program.opts();
+
+  const config: FpiConfig = {
+    logger: createConsoleLogger(Boolean(verbose)),
+    registryUrl,
+    registryToken,
+    cachePath,
+    skipExamples,
+    allowHttp,
+    requestTimeoutMs: requestTimeout,
+    extractTimeoutMs: extractTimeout,
+    registryTtlMs: registryTtl,
+  };
+
+  const fpi = new FhirPackageInstaller(config);
+
+  // Create a proxy that wraps all method calls with try-catch
+  return new Proxy(fpi, {
+    get(target, prop, receiver) {
+      const originalMethod = Reflect.get(target, prop, receiver);
+
+      // Only wrap functions (methods)
+      if (typeof originalMethod === 'function') {
+        return function (...args: unknown[]) {
+          try {
+            const result = originalMethod.apply(target, args);
+
+            // If the result is a Promise, wrap the promise with catch
+            if (result instanceof Promise) {
+              return result.catch((error: Error) => {
+                console.error(`Error in ${String(prop)}:`, error.message);
+                process.exit(1);
+              });
+            }
+
+            return result;
+          } catch (error) {
+            console.error(`Error in ${String(prop)}:`, (error as Error).message);
+            process.exit(1);
+          }
+        };
+      }
+
+      // Return non-function properties as-is
+      return originalMethod;
+    },
+  });
+}
+
+function print(data: unknown) {
+  if (typeof data === 'object') {
+    console.log(JSON.stringify(data, null, 2));
+  } else {
+    console.log(data);
+  }
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -140,10 +140,13 @@ program
   .alias('is')
   .description('Determine whether the package is already present in the local cache or not')
   .option('--shallow', 'Only check whether the package itself is installed; skip dependency validation')
+  .option('--raw', 'Print the raw boolean result (true/false) instead of a friendly message')
   .action(async (packageId, opts) => {
-    const fpi = createFpi();
+    const fpi = createFpi({ disableLogging: true });
     const isInstalled = await fpi.isInstalled(packageId, { deep: !opts.shallow });
-    if (isInstalled) {
+    if (opts.raw) {
+      print(isInstalled);
+    } else if (isInstalled) {
       print(`Package ${packageId} is already installed.`);
     } else {
       print(`Package ${packageId} is not installed.`);
@@ -192,7 +195,15 @@ function createConsoleLogger(verbose: boolean): Logger {
   return logger;
 }
 
-function createFpi() {
+function createSilentLogger(): Logger {
+  return {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  };
+}
+
+function createFpi(options?: { disableLogging?: boolean }): FhirPackageInstaller {
   const {
     registryUrl,
     registryToken,
@@ -206,7 +217,7 @@ function createFpi() {
   } = program.opts();
 
   const config: FpiConfig = {
-    logger: createConsoleLogger(Boolean(verbose)),
+    logger: options?.disableLogging ? createSilentLogger() : createConsoleLogger(Boolean(verbose)),
     registryUrl,
     registryToken,
     cachePath,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3566,16 +3566,16 @@ export class FhirPackageInstaller {
 
     const packageObject = await this.toPackageObject(packageId);
     const packageName = `${packageObject.id}@${packageObject.version}`;
-    
-    let finalPath = destination && path.isAbsolute(destination)
+
+    const resolvedDestination = destination && path.isAbsolute(destination)
       ? destination
       : path.join(path.resolve(destination ||'.'));
+    const downloadPath = path.join(resolvedDestination, `${packageObject.id}-${packageObject.version}.tgz`);
+    let finalPath = downloadPath;
     if (extract) {
-      finalPath = path.join(finalPath, await this.toDirName(packageObject));
-    } else {
-      finalPath = path.join(finalPath, `${packageObject.id}-${packageObject.version}.tgz`);
+      finalPath = path.join(resolvedDestination, await this.toDirName(packageObject));
     }
-    this.logger.info(`Downloading ${(extract ? 'and extracting ' : '')}${packageName} to: ${finalPath}`);
+    this.logger.info(`Downloading ${packageName} to: ${downloadPath}`);
 
     if (extract) {
       const tempDirectory = await this.downloadAndExtractTarball(packageObject);
@@ -3584,7 +3584,10 @@ export class FhirPackageInstaller {
       const tempDirectory = await this.downloadTarball(packageObject);
       await fs.move(tempDirectory, finalPath, { overwrite });
     }
-    this.logger.info(`Downloaded ${packageName} to: ${finalPath}`);
+    this.logger.info(`Downloaded ${packageName} to: ${downloadPath}`);
+    if (extract) {
+      this.logger.info(`Extracted ${packageName} to: ${finalPath}`);
+    }
     return finalPath;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3535,7 +3535,42 @@ export class FhirPackageInstaller {
 
       await fs.remove(await this.getPackageDirPath(packageObject));
 
-      await this.cachePackage(packageObject, finalPath, !isDirectory); // if the source is a file, we can move the temp dir to the cache
+      const cachedPackagePath = await this.cachePackage(packageObject, finalPath, !isDirectory); // if the source is a file, we can move the temp dir to the cache
+      const packageDir = path.join(cachedPackagePath, 'package');
+      const manifestPath = path.join(packageDir, 'package.json');
+
+      // generate a dummy manifest file in the cached directory if it doesn't exist
+      const packageStatus = await this.getPackageMaterializationStatus(packageObject);
+      const shouldGenerateDummyManifest = !packageStatus.complete && (
+        packageStatus.reason === 'manifest-missing' ||
+        packageStatus.reason === 'manifest-invalid'
+      );
+      if (shouldGenerateDummyManifest) {
+        const dummyManifest: PackageManifest = {
+          name: packageObject.id,
+          version: packageObject.version ?? '0.0.0',
+          fhirVersions: ['4.0.1'],
+        };
+        await fs.writeFile(manifestPath, JSON.stringify(dummyManifest, null, 2), 'utf8');
+        this.logger.debug?.(
+          `Generated dummy manifest for ${this.formatPackageForDebug(packageObject)} at ${manifestPath}.`
+        );
+      }
+
+      // if custom packageId was provided, we should verify that the manifest info matches the expected package id
+      if (options?.packageId) {
+        const manifest = await this.getManifest(packageObject);
+        const match = manifest.name === packageObject.id && manifest.version === packageObject.version;
+        if (!match) {
+          manifest.name = packageObject.id;
+          manifest.version = packageObject.version ?? manifest.version;
+          await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2), 'utf8');
+          this.logger.warn(
+            `The provided packageId (${packageObject.id}@${packageObject.version}) does not match the manifest in the package. ` +
+            `Updated manifest to match the provided packageId.`
+          );
+        }
+      }
 
       if (options?.installDependencies) {
         await this.installPackageDependencies(packageObject);

--- a/test/fhir-package-installer.test.ts
+++ b/test/fhir-package-installer.test.ts
@@ -1012,6 +1012,76 @@ describe('fhir-package-installer module', () => {
       await expect(fs.exists(indexPath)).resolves.toBe(true);
     });
 
+    it('writes a dummy manifest when the source has no package.json', { timeout: TIMEOUT }, async () => {
+      const dummyPkg = { id: 'dummy.no.manifest', version: '1.2.3' };
+      const dummySrcRoot = createTempDir();
+      const dummyPackageDir = path.join(dummySrcRoot, 'package');
+      await fs.ensureDir(dummyPackageDir);
+      // Put a resource file but no package.json
+      await fs.writeFile(
+        path.join(dummyPackageDir, 'StructureDefinition-foo.json'),
+        JSON.stringify({ resourceType: 'StructureDefinition', id: 'foo' }),
+      );
+
+      await expect(
+        customCacheFpi.installLocalPackage(dummySrcRoot, { packageId: `${dummyPkg.id}@${dummyPkg.version}`, installDependencies: false }),
+      ).resolves.toBe(true);
+
+      const cachedManifestPath = path.join(await customCacheFpi.getPackageDirPath(dummyPkg), 'package', 'package.json');
+      const written = await fs.readJSON(cachedManifestPath) as { name: string; version: string; fhirVersions?: string[] };
+      expect(written.name).toBe(dummyPkg.id);
+      expect(written.version).toBe(dummyPkg.version);
+      expect(written.fhirVersions).toEqual(['4.0.1']);
+
+      await fs.remove(dummySrcRoot);
+    });
+
+    it('rewrites the manifest and warns when a custom packageId does not match the source manifest', { timeout: TIMEOUT }, async () => {
+      const renamedPkg = { id: 'renamed.pkg', version: '9.9.9' };
+      const warn = vi.fn();
+      const reconcilingFpi = new FhirPackageInstaller({
+        cachePath: customCachePath,
+        allowHttp: true,
+        registryUrl: registry.getBaseUrl(),
+        logger: { info: () => {}, warn, error: () => {} },
+      });
+
+      await expect(
+        reconcilingFpi.installLocalPackage(fshGeneratedPath, { packageId: `${renamedPkg.id}@${renamedPkg.version}`, installDependencies: false }),
+      ).resolves.toBe(true);
+
+      const cachedManifestPath = path.join(await reconcilingFpi.getPackageDirPath(renamedPkg), 'package', 'package.json');
+      const written = await fs.readJSON(cachedManifestPath) as { name: string; version: string; fhirVersions?: string[] };
+      expect(written.name).toBe(renamedPkg.id);
+      expect(written.version).toBe(renamedPkg.version);
+      // Other manifest fields from the original source should be preserved.
+      expect(written.fhirVersions).toEqual(['4.0.1']);
+
+      const mismatchWarnings = warn.mock.calls.filter(([msg]) => typeof msg === 'string' && msg.includes('does not match the manifest in the package'));
+      expect(mismatchWarnings.length).toBe(1);
+    });
+
+    it('does not warn when a custom packageId matches the source manifest', { timeout: TIMEOUT }, async () => {
+      const warn = vi.fn();
+      const matchingFpi = new FhirPackageInstaller({
+        cachePath: customCachePath,
+        allowHttp: true,
+        registryUrl: registry.getBaseUrl(),
+        logger: { info: () => {}, warn, error: () => {} },
+      });
+
+      await expect(
+        matchingFpi.installLocalPackage(fshGeneratedPath, {
+          packageId: `${fshGeneratedPkg.id}@${fshGeneratedPkg.version}`,
+          override: true,
+          installDependencies: false,
+        }),
+      ).resolves.toBe(true);
+
+      const mismatchWarnings = warn.mock.calls.filter(([msg]) => typeof msg === 'string' && msg.includes('does not match the manifest in the package'));
+      expect(mismatchWarnings.length).toBe(0);
+    });
+
     // end of install local package tests
   });
 });

--- a/test/fhir-package-installer.test.ts
+++ b/test/fhir-package-installer.test.ts
@@ -900,6 +900,31 @@ describe('fhir-package-installer module', () => {
       await expect(action).resolves.toBeDefined();
     });
 
+    it('logs tarball download path separately from extracted folder path', { timeout: TIMEOUT }, async () => {
+      const info = vi.fn();
+      const logger: Logger = {
+        info,
+        warn: () => {},
+        error: () => {},
+      };
+      const loggingFpi = new FhirPackageInstaller({
+        allowHttp: true,
+        registryUrl: registry.getBaseUrl(),
+        logger,
+      });
+      const logDestination = path.join(downloadedPackagesPath, 'log-paths');
+      const resolvedLogDestination = path.resolve(logDestination);
+      const expectedDownloadPath = path.join(resolvedLogDestination, `${testPkg.id}-${testPkg.version}.tgz`);
+      const expectedExtractedPath = path.join(resolvedLogDestination, `${testPkg.id}#${testPkg.version}`);
+
+      const downloadedPath = await loggingFpi.downloadPackage(testPkg, { destination: logDestination, extract: true, overwrite: true });
+
+      expect(downloadedPath).toBe(expectedExtractedPath);
+      expect(info).toHaveBeenCalledWith(`Downloading ${testPkg.id}@${testPkg.version} to: ${expectedDownloadPath}`);
+      expect(info).toHaveBeenCalledWith(`Downloaded ${testPkg.id}@${testPkg.version} to: ${expectedDownloadPath}`);
+      expect(info).toHaveBeenCalledWith(`Extracted ${testPkg.id}@${testPkg.version} to: ${expectedExtractedPath}`);
+    });
+
     it.each([
       `${testPkg.id}@${testPkg.version}`,
       `${rootPkg.id}#${rootPkg.version}`

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -10,7 +10,7 @@ const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, 'package.json'), 'ut
 const version = pkg?.version ?? '0.0.0';
 
 export default defineConfig({
-  entry: ['src/index.ts', 'src/mock-artifactory-server.ts'],
+  entry: ['src/index.ts', 'src/mock-artifactory-server.ts', 'src/cli.ts'],
   dts: true,
   format: ['cjs', 'esm'],
   outDir: 'dist',
@@ -28,5 +28,15 @@ export default defineConfig({
   outExtension({ format }) {
     if (format === 'esm') return { js: '.mjs' };
     return { js: '.cjs' };
+  },
+  async onSuccess() {
+    const cliCjs = path.join(__dirname, 'dist', 'cli.cjs');
+    if (fs.existsSync(cliCjs)) {
+      const content = fs.readFileSync(cliCjs, 'utf8');
+      if (content.startsWith('#!') && !content.startsWith('#!/usr/bin/env node\r\n')) {
+        const patched = content.replace(/^(#![^\n]*)\r?\n/, '$1\r\n');
+        fs.writeFileSync(cliCjs, patched);
+      }
+    }
   }
 });


### PR DESCRIPTION
## Summary
Adds a fully-featured `fpi` CLI exposing every public `FhirPackageInstaller` method and `FpiConfig` option, plus a couple of supporting improvements.

- `fpi` bin covering `install`, `download`, `install-local`, `get-manifest`, `get-index`, `get-dependencies`, `to-package-object`, `check-latest`, `is-installed`, `get-cache`, `get-package-path`
- Global flags: `-r/--registry-url`, `-t/--registry-token`, `-c/--cache-path`, `-s/--skip-examples`, `--allow-http`, `--request-timeout`, `--extract-timeout`, `--registry-ttl`, `-v/--verbose`
- `is-installed --raw` prints a plain `true`/`false` (handy for scripting)
- `installLocalPackage` now writes a dummy manifest when the source has none, and reconciles the manifest when a custom `packageId` differs from the source
- `downloadPackage` logs the tarball path and the extracted directory path separately
- README CLI section + tests for the new behaviors

Supersedes #24.